### PR TITLE
Add redux cycle for table entries

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.19.2",
+    "concurrently": "^5.2.0",
     "jwt-decode": "^2.2.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/frontend/src/actions/budget_table_actions.js
+++ b/frontend/src/actions/budget_table_actions.js
@@ -32,10 +32,14 @@ export const fetchEntry = (entryId) => dispatch => ApiUtil.fetchEntry(entryId)
   .then(entry => dispatch(receiveTableEntry(entry)));
 
 export const createEntry = (entry) => dispatch => ApiUtil.createEntry(entry)
-  .then(entry => dispatch(receiveTableEntry(entry)));
+  .then(entry => dispatch(receiveTableEntry(entry)), err => (
+    dispatch(receiveEntryErrors(err))
+  ));
 
 export const updateEntry = (entry) => dispatch => ApiUtil.updateEntry(entry)
-  .then(entry => dispatch(receiveTableEntry(entry)));
+  .then(entry => dispatch(receiveTableEntry(entry)), err => (
+    dispatch(receiveEntryErrors(err))
+  ));
 
 export const deleteEntry = entryId => dispatch => ApiUtil.deleteEntry(entryId)
   .then(() => dispatch(removeTableEntry(entryId)));

--- a/frontend/src/actions/budget_table_actions.js
+++ b/frontend/src/actions/budget_table_actions.js
@@ -30,7 +30,7 @@ export const clearEntryErrors = () => ({
   type: CLEAR_ENTRY_ERRORS,
 });
 
-export const fetchEntries = (userId) => dispatch => ApiUtil.fetchEntries(userId)
+export const fetchEntries = () => dispatch => ApiUtil.fetchEntries()
   .then(entries => dispatch(receiveTableEntries(entries)));
 
 export const fetchEntry = (entryId) => dispatch => ApiUtil.fetchEntry(entryId)

--- a/frontend/src/actions/budget_table_actions.js
+++ b/frontend/src/actions/budget_table_actions.js
@@ -4,6 +4,7 @@ export const RECEIVE_TABLE_ENTRIES = "RECEIVE_ALL_TABLE_ENTRIES";
 export const RECEIVE_TABLE_ENTRY = "RECEIVE_TABLE_ENTRY";
 export const REMOVE_TABLE_ENTRY = "REMOVE_TABLE_ENTRY";
 export const RECEIVE_ENTRY_ERRORS = "RECEIVE_ENTRY_ERRORS";
+export const CLEAR_ENTRY_ERRORS = "CLEAR_ENTRY_ERRORS";
 
 export const receiveTableEntries = entries => ({
   type: RECEIVE_TABLE_ENTRIES,
@@ -23,6 +24,10 @@ export const removeTableEntry = entryId => ({
 export const receiveEntryErrors = errors => ({
   type: RECEIVE_ENTRY_ERRORS,
   errors
+});
+
+export const clearEntryErrors = () => ({
+  type: CLEAR_ENTRY_ERRORS,
 });
 
 export const fetchEntries = (userId) => dispatch => ApiUtil.fetchEntries(userId)

--- a/frontend/src/actions/budget_table_actions.js
+++ b/frontend/src/actions/budget_table_actions.js
@@ -1,3 +1,41 @@
 import * as ApiUtil from "../util/budget_table_api_util";
 
-// export const RECEIVE_ALL_TABLE_ENTRIES
+export const RECEIVE_TABLE_ENTRIES = "RECEIVE_ALL_TABLE_ENTRIES";
+export const RECEIVE_TABLE_ENTRY = "RECEIVE_TABLE_ENTRY";
+export const REMOVE_TABLE_ENTRY = "REMOVE_TABLE_ENTRY";
+export const RECEIVE_ENTRY_ERRORS = "RECEIVE_ENTRY_ERRORS";
+
+export const receiveTableEntries = entries => ({
+  type: RECEIVE_TABLE_ENTRIES,
+  entries
+});
+
+export const receiveTableEntry = entry => ({
+  type: RECEIVE_TABLE_ENTRY,
+  entry
+});
+
+export const removeTableEntry = entryId => ({
+  type: REMOVE_TABLE_ENTRY,
+  entryId
+});
+
+export const receiveEntryErrors = errors => ({
+  type: RECEIVE_ENTRY_ERRORS,
+  errors
+});
+
+export const fetchEntries = (userId) => dispatch => ApiUtil.fetchEntries(userId)
+  .then(entries => dispatch(receiveTableEntries(entries)));
+
+export const fetchEntry = (entryId) => dispatch => ApiUtil.fetchEntry(entryId)
+  .then(entry => dispatch(receiveTableEntry(entry)));
+
+export const createEntry = (entry) => dispatch => ApiUtil.createEntry(entry)
+  .then(entry => dispatch(receiveTableEntry(entry)));
+
+export const updateEntry = (entry) => dispatch => ApiUtil.updateEntry(entry)
+  .then(entry => dispatch(receiveTableEntry(entry)));
+
+export const deleteEntry = entryId => dispatch => ApiUtil.deleteEntry(entryId)
+  .then(() => dispatch(removeTableEntry(entryId)));

--- a/frontend/src/reducers/budget_table_errors_reducer.js
+++ b/frontend/src/reducers/budget_table_errors_reducer.js
@@ -1,0 +1,13 @@
+import { RECEIVE_ENTRY_ERRORS } from "../actions/budget_table_actions";
+
+export default (state = [], action) => {
+  Object.freeze(state);
+  switch (action.type) {
+    case RECEIVE_ENTRY_ERRORS:
+      return action.errors;
+    case CLEAR_ENTRY_ERRORS:
+      return [];
+    default:
+      return state;
+  }
+};

--- a/frontend/src/reducers/budget_tables_reducer.js
+++ b/frontend/src/reducers/budget_tables_reducer.js
@@ -1,0 +1,21 @@
+import { RECEIVE_TABLE_ENTRIES, RECEIVE_TABLE_ENTRY, REMOVE_TABLE_ENTRY } from "../actions/budget_table_actions";
+
+const budgetTablesReducer = (state = {}, action) => {
+  Object.freeze(state);
+  let nextState = Object.assign({}, state);
+
+  switch (action.type) {
+    case RECEIVE_TABLE_ENTRIES:
+      return action.entries;
+    case RECEIVE_TABLE_ENTRY:
+      const newEntry = { [action.entry.id]: action.entry };
+      return Object.assign({}, nextState, newEntry);
+    case REMOVE_TABLE_ENTRY:
+      delete nextState[action.entryId];
+      return nextState;
+    default:
+      return state;
+  }
+}
+
+export default budgetTablesReducer;

--- a/frontend/src/reducers/errors_reducer.js
+++ b/frontend/src/reducers/errors_reducer.js
@@ -1,7 +1,9 @@
 import { combineReducers } from "redux";
 
+import EntryErrorsReducer from "./budget_table_errors_reducer"
 import SessionErrorsReducer from "./session_errors_reducer";
 
 export default combineReducers({
   session: SessionErrorsReducer,
+  entry: EntryErrorsReducer,
 });

--- a/frontend/src/reducers/root_reducer.js
+++ b/frontend/src/reducers/root_reducer.js
@@ -1,9 +1,11 @@
 import { combineReducers } from "redux";
 import session from "./session_reducer.js";
 import errors from "./errors_reducer"
+import budgetTablesReducer from "./budget_tables_reducer"
 
 const RootReducer = combineReducers({
   session: session,
+  budgetTable: budgetTablesReducer,
   errors: errors
 });
 

--- a/frontend/src/util/budget_table_api_util.js
+++ b/frontend/src/util/budget_table_api_util.js
@@ -13,8 +13,8 @@ export const createEntry = (entry) => {
   return axois.post("/api/tables/new", entry);
 };
 
-export const updateEntry = (entryId) => {
-  return axois.patch(`/api/tables/${entryId}`);
+export const updateEntry = (entry) => {
+  return axois.patch(`/api/tables/${entry.id}`);
 };
 
 export const deleteEntry = (entryId) => {

--- a/frontend/src/util/budget_table_api_util.js
+++ b/frontend/src/util/budget_table_api_util.js
@@ -1,22 +1,22 @@
 import axois from "axios";
 
 // routes might change based on backend
-export const fetchEntries = (userId) => {
-  return axois.get("/api/tables", userId);
+export const fetchEntries = () => {
+  return axois.get("/api/entries", userId);
 };
 
 export const fetchEntry = (entryId) => {
-  return axois.get(`/api/tables/${entryId}`)
+  return axois.get(`/api/entries/${entryId}`)
 };
 
 export const createEntry = (entry) => {
-  return axois.post("/api/tables/new", entry);
+  return axois.post("/api/entries/new", entry);
 };
 
 export const updateEntry = (entry) => {
-  return axois.patch(`/api/tables/${entry.id}`);
+  return axois.patch(`/api/entries/${entry.id}`);
 };
 
 export const deleteEntry = (entryId) => {
-  return axois.delete(`/api/tables/${entryId}`);
+  return axois.delete(`/api/entries/${entryId}`);
 };

--- a/package.json
+++ b/package.json
@@ -5,13 +5,18 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "server": "nodemon app.js"
+    "server": "nodemon app.js",
+    "debug": "node --inspect app.js",
+    "frontend-install": "npm install --prefix frontend",
+    "frontend": "npm start --prefix frontend",
+    "dev": "concurrently \"npm run server\" \"npm run frontend\""
   },
   "author": "brian, shaphen, eddie, natalie",
   "license": "ISC",
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
+    "concurrently": "^5.2.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.9.13",


### PR DESCRIPTION
### Main features
* Added redux cycle for Budget Table Entries
* Fixed `npm run dev` bug for concurrent server execution
___
#### utilized `axois` calls to backend with presumed routes. Can edit accordingly.
```javascript
export const fetchEntry = (entryId) => {
  return axois.get(`/api/tables/${entryId}`)
};
```

#### created thunk actions based on FSP worfklow:
```javascript
export const fetchEntry = (entryId) => dispatch => ApiUtil.fetchEntry(entryId)
  .then(entry => dispatch(receiveTableEntry(entry)));
```

#### budget tables also resembles FSP workflow
* Specifically `RECEIVE_TABLE_ENTRY` was considered to potentially require refactoring 
```javascript
const budgetTablesReducer = (state = {}, action) => {
  Object.freeze(state);
  let nextState = Object.assign({}, state);

  switch (action.type) {
    case RECEIVE_TABLE_ENTRIES:
      return action.entries;
    case RECEIVE_TABLE_ENTRY:
      const newEntry = { [action.entry.id]: action.entry };
      return Object.assign({}, nextState, newEntry);
    case REMOVE_TABLE_ENTRY:
      delete nextState[action.entryId];
      return nextState;
    default:
      return state;
  }
}
```

#### created a separate reducer for errors and included `CLEAR_ENTRY_ERRORS` feature:
```javascript
export default (state = [], action) => {
  Object.freeze(state);
  switch (action.type) {
    case RECEIVE_ENTRY_ERRORS:
      return action.errors;
    case CLEAR_ENTRY_ERRORS:
      return [];
    default:
      return state;
  }
};
```

#### Fixed bug with `npm run dev`
* core problem was lacking adequate package.json scripts and not running `npm install concurrently`
  * It will likely not be necessary to run `npm install concurrently` on your local directory but if problem persists consider running it
* please note you will need to `npm install` BOTH backend and frontend to apply package.json changes