### PR TITLE
Add redux cycle fire numbers

### DIFF
--- a/frontend/src/actions/user_actions.js
+++ b/frontend/src/actions/user_actions.js
@@ -1,0 +1,28 @@
+import * as ApiUtil from "../util/user_api_util";
+
+export const RECEIVE_FI_DATA = "RECEIVE_FI_DATA";
+export const RECEIVE_FI_ERRORS = "RECEIVE_FI_ERRORS";
+export const CLEAR_FI_ERRORS = "CLEAR_FI_ERRORS";
+
+export const receiveFiData = data => ({
+  type: RECEIVE_FI_DATA,
+  data
+});
+
+export const receiveFiErrors = errors => ({
+  type: RECEIVE_FI_ERRORS,
+  errors
+});
+
+export const clearFiErrors = () => ({
+  type: CLEAR_FI_ERRORS
+});
+
+export const fetchFiData = (userId) => dispatch => ApiUtil.fetchFiData(userId)
+  .then(data => dispatch(receiveFiData(data)));
+
+export const updateFiNum = (user, fireNum) => dispatch => ApiUtil.updateFiNum(user, fireNum)
+  .then(data => dispatch(receiveFiData(data)));
+
+export const updateYearsToFI = (user, yearsToFI) => dispatch => ApiUtil.updateYearsToFI(user, yearsToFI)
+  .then(data => dispatch(receiveFiData(data)));

--- a/frontend/src/components/budget/budget_list_item.jsx
+++ b/frontend/src/components/budget/budget_list_item.jsx
@@ -20,11 +20,11 @@ const BudgetListItem = ({ deleteEntry, updateEntry, entry }) => {
       <p>{entry.description}</p>
       <p>{entry.category}</p>
       <p id="budget-list-date">{newDate}</p>
-      <label id="budget-item-change">
-        <button id="budget-item-delete-button" onClick={() => deleteEntry(entry._id)}>Delete</button>
+      <label id="budget-item-change" onClick={() => deleteEntry(entry._id)}>
+        <button id="budget-item-delete-button">Delete</button>
       </label>
-      <label id="budget-item-change">
-        <button id="budget-item-delete-button" onClick={() => setModalIsOpen(true)}>Edit</button>
+      <label id="budget-item-change" onClick={() => setModalIsOpen(true)}>
+        <button id="budget-item-delete-button">Edit</button>
       </label>
       <Modal isOpen={modalIsOpen} onRequestClose={() => setModalIsOpen(false)}>
         <EditBudgetItem 

--- a/frontend/src/reducers/errors_reducer.js
+++ b/frontend/src/reducers/errors_reducer.js
@@ -2,8 +2,10 @@ import { combineReducers } from "redux";
 
 import EntryErrorsReducer from "./budget_table_errors_reducer"
 import SessionErrorsReducer from "./session_errors_reducer";
+import userErrors from "./user_errors_reducer";
 
 export default combineReducers({
   session: SessionErrorsReducer,
   entry: EntryErrorsReducer,
+  user: userErrors
 });

--- a/frontend/src/reducers/root_reducer.js
+++ b/frontend/src/reducers/root_reducer.js
@@ -1,10 +1,13 @@
 import { combineReducers } from "redux";
+
 import session from "./session_reducer.js";
 import errors from "./errors_reducer"
 import budgetTablesReducer from "./budget_tables_reducer"
+import usersReducer from "./users_reducer";
 
 const RootReducer = combineReducers({
   session: session,
+  user: usersReducer,
   budgetTable: budgetTablesReducer,
   errors: errors
 });

--- a/frontend/src/reducers/user_errors_reducer.js
+++ b/frontend/src/reducers/user_errors_reducer.js
@@ -1,0 +1,13 @@
+import { RECEIVE_FI_ERRORS, CLEAR_FI_ERRORS } from "../actions/user_actions";
+
+export default (state = [], action) => {
+  Object.freeze(state);
+  switch (action.type) {
+    case RECEIVE_FI_ERRORS:
+      return action.errors
+    case CLEAR_FI_ERRORS:
+      return [];
+    default:
+      return state;
+  }
+}

--- a/frontend/src/reducers/users_reducer.js
+++ b/frontend/src/reducers/users_reducer.js
@@ -2,7 +2,7 @@ import { RECEIVE_FI_DATA } from "../actions/user_actions";
 
 const usersReducer = (state = {}, action) => {
   Object.freeze(state);
-  nextState = Object.assign({}, state);
+  let nextState = Object.assign({}, state);
 
   switch (action.type) {
     case RECEIVE_FI_DATA:

--- a/frontend/src/reducers/users_reducer.js
+++ b/frontend/src/reducers/users_reducer.js
@@ -1,0 +1,15 @@
+import { RECEIVE_FI_DATA } from "../actions/user_actions";
+
+const usersReducer = (state = {}, action) => {
+  Object.freeze(state);
+  nextState = Object.assign({}, state);
+
+  switch (action.type) {
+    case RECEIVE_FI_DATA:
+      return action.data;
+    default:
+      return state;
+  }
+}
+
+export default usersReducer;

--- a/frontend/src/util/user_api_util.js
+++ b/frontend/src/util/user_api_util.js
@@ -4,10 +4,10 @@ export const fetchFiData = (userId) => {
   return axios.patch(`/api/user/${userId}`);
 };
 
-export const updateFiNum = (user, fiNum) => {
-  return axios.patch(`/api/user/${user._id}`, fiNum);
+export const updateFiNum = (user, fireNum) => {
+  return axios.patch(`/api/user/${user._id}`, fireNum);
 };
 
-export const updateNumYears = (user, numYears) => {
-  return axios.patch(`/api/user/${user._id}`, numYears);
+export const updateYearsToFI = (user, yearsToFI) => {
+  return axios.patch(`/api/user/${user._id}`, yearsToFI);
 };

--- a/frontend/src/util/user_api_util.js
+++ b/frontend/src/util/user_api_util.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+export const fetchFiData = (userId) => {
+  return axios.patch(`/api/user/${userId}`);
+};
+
+export const updateFiNum = (user, fiNum) => {
+  return axios.patch(`/api/user/${user._id}`, fiNum);
+};
+
+export const updateNumYears = (user, numYears) => {
+  return axios.patch(`/api/user/${user._id}`, numYears);
+};


### PR DESCRIPTION
`user_api_util` grabs the data SEPARATELY for `fireNum` and `yearsToFI`

```javascript
export const fetchFiData = (userId) => {
  return axios.patch(`/api/user/${userId}`);
};

export const updateFiNum = (user, fireNum) => {
  return axios.patch(`/api/user/${user._id}`, fireNum);
};

export const updateYearsToFI = (user, yearsToFI) => {
  return axios.patch(`/api/user/${user._id}`, yearsToFI);
};
```

It is assumed that regardless of which is updated that only a single object with both values are returned

```javascript
export const receiveFiData = data => ({
  type: RECEIVE_FI_DATA,
  data
});
```
* Note the reducer also reflects this assumption

result will show in state nested in `user`
errors will show under `errors.user`